### PR TITLE
Update README.md - npm ci instead of i

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Install global npm packages:
 Navigate to the momenTUM-app folder and install the dependencies:
 
       cd /path/to/momenTUM-app
-      npm i
+      npm ci
 
 ## Build and run project
 


### PR DESCRIPTION
If package-json.lock is available then npm ci will only and exactly install the dependencies, without ever changing package.json or package-json.lock

This is especially usefull, as the version of software libraries is not changed without consent.

npm ci is used for the deterministic, repeatable build.

Details see:
https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci https://www.geeksforgeeks.org/difference-between-npm-i-and-npm-ci-in-node-js/

The change:
npm ci -g @ionic/cli @angular/cli native-run cordova-res

Might not be usefull, as this especially installs global dependencies. It should be reviewed.

Anyhow it would be good to a a docker-compose file for installing "npm" inside the container and not globally.